### PR TITLE
Simplify to use a single file format

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 #[command(author = "febkor", version = "1", about, long_about = None)]
 pub struct Config {
     /// Directory where to store snaps.
-    #[arg(short, long, default_value = "~/selfprof")]
+    #[arg(short, long)]
     pub out_dir: String,
 
     /// Seconds between each snap.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::VecDeque,
     ffi::{CStr, CString},
+    ops::Deref,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -47,6 +49,36 @@ impl Snap {
             index,
             name,
         }
+    }
+}
+
+pub struct RingBuf<T> {
+    capacity: usize,
+    buf: VecDeque<T>,
+}
+
+impl<T> RingBuf<T> {
+    pub fn with_capacity(capacity: usize) -> RingBuf<T> {
+        RingBuf {
+            capacity,
+            buf: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    pub fn push(&mut self, value: T) {
+        if self.buf.len() == self.capacity {
+            self.buf.pop_front();
+        }
+
+        self.buf.push_back(value);
+    }
+}
+
+impl<T> Deref for RingBuf<T> {
+    type Target = VecDeque<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    mem::size_of,
+    ffi::{CStr, CString},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -11,22 +11,42 @@ const APP_EPOCH_OFFSET: u64 = 1577836800;
 
 pub mod storage;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Snap {
     pub time: u32, // ~136y
-    pub name: u32, // ~4bn, excessive
     pub idle: u16, // ~18h
-    pub pad: u16,
+    pub index: u8, // lookback index for name
+    pub name: CString,
 }
 
 impl Snap {
-    pub fn to_bytes(self: &Snap) -> [u8; 12] {
-        const N: usize = size_of::<Snap>();
-        let mut res = [0u8; N];
-        res[0..4].copy_from_slice(&self.time.to_be_bytes());
-        res[4..8].copy_from_slice(&self.name.to_be_bytes());
-        res[8..10].copy_from_slice(&self.idle.to_be_bytes());
+    pub fn count_bytes(self: &Snap) -> usize {
+        4 + 2 + 1 + self.name.as_bytes_with_nul().len()
+    }
+
+    pub fn to_bytes(self: &Snap) -> Vec<u8> {
+        let name = self.name.as_bytes_with_nul();
+        let mut res = Vec::<u8>::with_capacity(self.count_bytes());
+        res.extend(&self.time.to_be_bytes());
+        res.extend(&self.idle.to_be_bytes());
+        res.extend(&self.index.to_be_bytes());
+        res.extend(name);
         res
+    }
+
+    pub fn from_bytes(buf: &[u8]) -> Snap {
+        let time = u32::from_be_bytes(*<&[u8; 4]>::try_from(&buf[0..4]).expect("enough bytes"));
+        let idle = u16::from_be_bytes(*<&[u8; 2]>::try_from(&buf[4..6]).expect("enough bytes"));
+        let index = u8::from_be_bytes(*<&[u8; 1]>::try_from(&buf[6..7]).expect("enough bytes"));
+        let name: CString = CStr::from_bytes_until_nul(&buf[7..])
+            .expect("valid C string")
+            .into();
+        Snap {
+            time,
+            idle,
+            index,
+            name,
+        }
     }
 }
 
@@ -47,5 +67,23 @@ pub fn active_app_name() -> String {
     match get_active_window() {
         Ok(w) => format!("{} : {}", w.process_name, w.title),
         Err(_) => "".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip() {
+        let s = Snap {
+            time: 123456,
+            idle: 78,
+            index: 9,
+            name: CString::new("test").unwrap(),
+        };
+        let bytes = s.to_bytes();
+        let r = Snap::from_bytes(&bytes);
+        assert_eq!(r, s);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::VecDeque,
     ffi::CString,
-    mem::size_of,
     path::Path,
     thread,
     time::{self},
@@ -11,8 +10,7 @@ use selfprof::{active_app_name, idle_time, storage, time_now, Snap};
 
 mod cli;
 
-type Name = String;
-type NameId = u32;
+type Name = CString;
 
 fn main() {
     let config = cli::parse();
@@ -31,34 +29,64 @@ fn main() {
     let dir_path = &Path::new(&config.out_dir);
     std::fs::create_dir_all(dir_path).expect("create output directory");
     let snaps_path = dir_path.join("selfprof.dat");
-    let snaps = storage::load_snaps(&snaps_path);
 
+    const MAX_NAME_LOOKBACK: usize = u8::MAX as usize;
     let mut snaps: Vec<Snap> = Vec::with_capacity(snaps_per_save);
-    const MAX_NAME_LOOKBACK: usize = size_of::<u8>();
     let mut names: VecDeque<Name> = VecDeque::with_capacity(MAX_NAME_LOOKBACK);
 
+    {
+        // Load snaps to initialize names
+        let snaps_prev = storage::load_snaps(&snaps_path);
+        for snap in snaps_prev {
+            if config.verbose {
+                println!("Loaded {:?}", snap);
+            }
+
+            if names.len() == MAX_NAME_LOOKBACK {
+                names.pop_front();
+            }
+            names.push_back(snap.name);
+        }
+    }
+
     loop {
-        for _ in 1..=snaps_per_save {
+        for _ in 0..snaps_per_save {
             thread::sleep(interval);
             let idle = idle_time();
             if idle > config.idle_cutoff {
                 continue;
             }
+            let time = time_now();
             let name = active_app_name();
-
-            // TODO: find rindex (reverse!)
-            let index = names.iter().position(|x| x == &name).unwrap_or(0);
+            let index: u8 = names
+                .iter()
+                .rev()
+                .position(|x| x.as_bytes() == name.as_bytes())
+                .unwrap_or(MAX_NAME_LOOKBACK)
+                .try_into()
+                .unwrap_or(MAX_NAME_LOOKBACK as u8);
+            let name_exists = index < MAX_NAME_LOOKBACK as u8;
 
             let snap = Snap {
-                time: time_now(),
-                idle: idle,
-                index: index.try_into().unwrap_or(0),
-                // TODO: only write if index == 0
-                name: CString::new(name).expect("No nul"),
+                time,
+                idle,
+                index,
+                name: if name_exists {
+                    CString::default()
+                } else {
+                    CString::new(name.clone()).expect("No nul")
+                },
             };
 
             if config.verbose {
                 println!("{:?}", &snap);
+            }
+
+            if !name_exists {
+                if names.len() == MAX_NAME_LOOKBACK {
+                    names.pop_front();
+                }
+                names.push_back(CString::new(name.clone()).expect("No nul"));
             }
 
             snaps.push(snap);
@@ -70,7 +98,6 @@ fn main() {
 
         storage::update_snaps(&snaps, &snaps_path, |s| s.to_bytes());
 
-        names.clear();
         snaps.clear();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,11 @@ fn main() {
                 continue;
             }
             let time = time_now();
-            let name = active_app_name();
+            let name = CString::new(active_app_name()).expect("No nul");
             let index: u8 = names
                 .iter()
                 .rev()
-                .position(|x| x.as_bytes() == name.as_bytes())
+                .position(|x| x == &name)
                 .unwrap_or(MAX_NAME_LOOKBACK)
                 .try_into()
                 .unwrap_or(MAX_NAME_LOOKBACK as u8);
@@ -70,7 +70,7 @@ fn main() {
                 name: if name_exists {
                     CString::default()
                 } else {
-                    CString::new(name.clone()).expect("No nul")
+                    name.clone()
                 },
             };
 
@@ -79,7 +79,7 @@ fn main() {
             }
 
             if !name_exists {
-                names.push(CString::new(name.clone()).expect("No nul"));
+                names.push(name);
             }
 
             snaps.push(snap);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,21 +33,10 @@ fn main() {
     let mut snaps: Vec<Snap> = Vec::with_capacity(snaps_per_save);
     let mut names: RingBuf<Name> = RingBuf::with_capacity(MAX_NAME_LOOKBACK);
 
-    {
-        // Load snaps to initialize names
-        let snaps_prev = storage::load_snaps(&snaps_path);
-        for snap in snaps_prev {
-            if config.verbose {
-                println!("Loaded {:?}", snap);
-            }
-
-            names.push(snap.name);
-        }
-    }
-
     loop {
         for _ in 0..snaps_per_save {
             thread::sleep(interval);
+
             let idle = idle_time();
             if idle > config.idle_cutoff {
                 continue;
@@ -90,7 +79,6 @@ fn main() {
         }
 
         storage::update_snaps(&snaps, &snaps_path, |s| s.to_bytes());
-
         snaps.clear();
     }
 }


### PR DESCRIPTION
Use a look-back index to store the app names in the snaps file.
